### PR TITLE
Use DisplayName instead of methodName

### DIFF
--- a/src/JunitTestLogger/JUnitXmlTestLogger.cs
+++ b/src/JunitTestLogger/JUnitXmlTestLogger.cs
@@ -190,6 +190,8 @@ namespace JUnit.TestLogger
         {
             TestResult result = e.Result;
 
+            var displayName = string.IsNullOrEmpty(result.DisplayName) ? result.TestCase.DisplayName : result.DisplayName;
+
             if (TryParseName(result.TestCase.FullyQualifiedName, out var typeName, out var methodName, out _))
             {
                 lock (resultsGuard)
@@ -200,7 +202,7 @@ namespace JUnit.TestLogger
                         result.TestCase.Source,
                         typeName,
                         methodName,
-                        result.TestCase.DisplayName,
+                        displayName,
                         result.Duration,
                         result.ErrorMessage,
                         result.ErrorStackTrace,
@@ -369,7 +371,7 @@ namespace JUnit.TestLogger
         {
             var element = new XElement("testcase",
                 new XAttribute("classname", result.Type),
-                new XAttribute("name", result.Method),
+                new XAttribute("name", result.Name),
                 new XAttribute("time", result.Time.TotalSeconds.ToString("N7", CultureInfo.InvariantCulture)));
 
             if (result.Outcome == TestOutcome.Failed)


### PR DESCRIPTION
This change uses the `TestResult.DisplayName` or `TestResult.TestCase.DisplayName` as the value of the `name` attribute of `testCase` elements.

This has the following benefits over using the name of the test method:
1. It includes the namespace and type name for disambiguation of similarly named tests
2. In case of theory tests, it includes the values of the parameters for disambiguation

The change should match the behavior of the TrxLogger, see https://github.com/Microsoft/vstest/blob/master/src/Microsoft.TestPlatform.Extensions.TrxLogger/TrxLogger.cs#L546 for details.

This PR does introduce a change in behavior and may need additional polishing. I'm putting it up here to gather visibility and gather feedback. Please let me know what you thoughts are.