### PR TITLE
Used AssemblyName class to extract assembly name

### DIFF
--- a/src/JunitTestLogger/JUnitXmlTestLogger.cs
+++ b/src/JunitTestLogger/JUnitXmlTestLogger.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -290,7 +291,7 @@ namespace JUnit.TestLogger
 
             element.Add(allCases);
 
-            var assemblyName = assemblyPath.Split('\\').Last();
+            var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
 
             element.SetAttributeValue("id", index);
             element.SetAttributeValue("name", assemblyName);


### PR DESCRIPTION
This changes the mechanism of retrieving the assembly name to use the AssemblyName class, as the existing method was failing running on Linux because of the difference in path separators.